### PR TITLE
imported pathfinding demo

### DIFF
--- a/Assets/Prefabs/Pathfinding_Demo.meta
+++ b/Assets/Prefabs/Pathfinding_Demo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e0065a81d3815f459303cb9409c9d2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Pathfinding_Demo/NPC.prefab
+++ b/Assets/Prefabs/Pathfinding_Demo/NPC.prefab
@@ -1,0 +1,266 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &130613448432630493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7162010459137496012}
+  - component: {fileID: 1122983733336015164}
+  m_Layer: 6
+  m_Name: Front
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7162010459137496012
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130613448432630493}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.25, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 6823338258807773295}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1122983733336015164
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130613448432630493}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!1 &2467229450485462925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6609317091138904717}
+  - component: {fileID: 7530529921519173166}
+  m_Layer: 0
+  m_Name: NPC
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6609317091138904717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2467229450485462925}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6823338258807773295}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7530529921519173166
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2467229450485462925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dce2799d57e8c944da061cd159cf2376, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NPC
+  moveSpeed: 1
+  turnSpeed: 720
+  arrivedDistance: 0.02
+  debugMove: {x: 10, y: 10}
+--- !u!1 &4131433657981003965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6823338258807773295}
+  m_Layer: 6
+  m_Name: Visual
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6823338258807773295
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4131433657981003965}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7162010459137496012}
+  - {fileID: 4851144736266010826}
+  m_Father: {fileID: 6609317091138904717}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4448173096282115031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4851144736266010826}
+  - component: {fileID: 167939469772018016}
+  m_Layer: 6
+  m_Name: Body
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4851144736266010826
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4448173096282115031}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 0.6}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 6823338258807773295}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &167939469772018016
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4448173096282115031}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.5471698, g: 0.022563228, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/Pathfinding_Demo/NPC.prefab.meta
+++ b/Assets/Prefabs/Pathfinding_Demo/NPC.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 226edf6ba9d149d45be51a1fdc503aea
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Pathfinding_Demo/Square.prefab
+++ b/Assets/Prefabs/Pathfinding_Demo/Square.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3145585899364901508
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8264569112211030318}
+  - component: {fileID: 8816538503727084931}
+  m_Layer: 7
+  m_Name: Square
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8264569112211030318
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3145585899364901508}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8816538503727084931
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3145585899364901508}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/Pathfinding_Demo/Square.prefab.meta
+++ b/Assets/Prefabs/Pathfinding_Demo/Square.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4f9d0e11810036642995ff068ed00b86
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Jackie_Pathfinding.meta
+++ b/Assets/Scenes/Jackie_Pathfinding.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 529b99db940077a41b7f402ac819447e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Jackie_Pathfinding/Pathfinding.unity
+++ b/Assets/Scenes/Jackie_Pathfinding/Pathfinding.unity
@@ -1,0 +1,492 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &519420028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 519420032}
+  - component: {fileID: 519420031}
+  - component: {fileID: 519420029}
+  - component: {fileID: 519420030}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &519420029
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+--- !u!114 &519420030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!20 &519420031
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 34
+  orthographic: 1
+  orthographic size: 10
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 0
+  m_HDR: 1
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &519420032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5, y: 5, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &619394800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 619394802}
+  - component: {fileID: 619394801}
+  m_Layer: 0
+  m_Name: Global Light 2D
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &619394801
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 619394800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 073797afb82c5a1438f328866b10b3f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ComponentVersion: 2
+  m_LightType: 4
+  m_BlendStyleIndex: 0
+  m_FalloffIntensity: 0.5
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_LightVolumeIntensity: 1
+  m_LightVolumeEnabled: 0
+  m_ApplyToSortingLayers: 00000000
+  m_LightCookieSprite: {fileID: 0}
+  m_DeprecatedPointLightCookieSprite: {fileID: 0}
+  m_LightOrder: 0
+  m_AlphaBlendOnOverlap: 0
+  m_OverlapOperation: 0
+  m_NormalMapDistance: 3
+  m_NormalMapQuality: 2
+  m_UseNormalMap: 0
+  m_ShadowsEnabled: 0
+  m_ShadowIntensity: 0.75
+  m_ShadowSoftness: 0
+  m_ShadowSoftnessFalloffIntensity: 0.5
+  m_ShadowVolumeIntensityEnabled: 0
+  m_ShadowVolumeIntensity: 0.75
+  m_LocalBounds:
+    m_Center: {x: 0, y: -0.00000011920929, z: 0}
+    m_Extent: {x: 0.9985302, y: 0.99853027, z: 0}
+  m_PointLightInnerAngle: 360
+  m_PointLightOuterAngle: 360
+  m_PointLightInnerRadius: 0
+  m_PointLightOuterRadius: 1
+  m_ShapeLightParametricSides: 5
+  m_ShapeLightParametricAngleOffset: 0
+  m_ShapeLightParametricRadius: 1
+  m_ShapeLightFalloffSize: 0.5
+  m_ShapeLightFalloffOffset: {x: 0, y: 0}
+  m_ShapePath:
+  - {x: -0.5, y: -0.5, z: 0}
+  - {x: 0.5, y: -0.5, z: 0}
+  - {x: 0.5, y: 0.5, z: 0}
+  - {x: -0.5, y: 0.5, z: 0}
+--- !u!4 &619394802
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 619394800}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &811027743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 811027745}
+  - component: {fileID: 811027744}
+  m_Layer: 0
+  m_Name: NPC SPAWNER
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &811027744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 811027743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a6002d79961bf0649a1df7133628caa3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NPCSpawner
+  agent: {fileID: 2467229450485462925, guid: 226edf6ba9d149d45be51a1fdc503aea, type: 3}
+  nToSpawn: 0
+  grid: {fileID: 1636873077}
+  spawned: 0
+--- !u!4 &811027745
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 811027743}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.1019, y: 4.33036, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1636873075
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1636873076}
+  - component: {fileID: 1636873077}
+  m_Layer: 0
+  m_Name: Grid
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1636873076
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1636873075}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1636873077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1636873075}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3515abf6f8e8a8f4598b3ebaeaf6a1a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Grid
+  targetIdx: 9
+  prefab: {fileID: 3145585899364901508, guid: 4f9d0e11810036642995ff068ed00b86, type: 3}
+  origin: {fileID: 1636873076}
+--- !u!1 &1961195246
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1961195248}
+  - component: {fileID: 1961195247}
+  m_Layer: 0
+  m_Name: NPC SYSTEM
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1961195247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961195246}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 862595f16f44d8244acec5349546fed1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::NPCNetwork
+  spawner: {fileID: 811027744}
+  square: {fileID: 3145585899364901508, guid: 4f9d0e11810036642995ff068ed00b86, type: 3}
+--- !u!4 &1961195248
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961195246}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 519420032}
+  - {fileID: 619394802}
+  - {fileID: 1636873076}
+  - {fileID: 1961195248}
+  - {fileID: 811027745}

--- a/Assets/Scenes/Jackie_Pathfinding/Pathfinding.unity.meta
+++ b/Assets/Scenes/Jackie_Pathfinding/Pathfinding.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: added959a1e4a8443bccb89bd06bdaac
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pathfinding_Scripts.meta
+++ b/Assets/Scripts/Pathfinding_Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52ed693f54346944ead5f2f795e6017c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pathfinding_Scripts/BbGrid.cs
+++ b/Assets/Scripts/Pathfinding_Scripts/BbGrid.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Serialization;
+using UnityEngine.UI;
+
+public class BbGrid : MonoBehaviour
+{
+    [FormerlySerializedAs("targetIndex")] public int targetIdx;
+    public GameObject prefab;
+
+    public Transform origin;
+    
+    private Bitboard _bb;
+
+    [NonSerialized] public GameObject[] squares;
+    [NonSerialized] public int[] distances = new int[64];
+
+    [NonSerialized] public bool initialized = false;
+    
+    private const ulong 
+        northMask   = 0x00FFFFFFFFFFFFFFUL,
+        southMask   = 0xFFFFFFFFFFFFFF00UL,
+        westMask    = 0x7F7F7F7F7F7F7F7FUL,
+        eastMask    = 0xFEFEFEFEFEFEFEFEUL;
+    
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        /*
+        '0' = obstacle, '1' = open
+        0 0 0 0 0 0 0 0
+        0 1 1 1 1 1 1 0
+        0 1 0 0 0 1 1 0
+        0 1 1 1 0 1 1 0
+        0 1 0 0 0 1 1 0
+        0 1 1 1 0 0 0 0
+        1 1 0 1 1 1 1 0
+        0 0 0 0 0 0 0 0
+        */
+        // 0000000001111110010001100111111001111010011000101111111000000000
+        
+        _bb.setData(0b0000000001111110010001100111011001000110011101001101111000000000);
+
+        squares = new GameObject[64];
+        const int defaultValue = -1;
+        Array.Fill(distances, defaultValue);
+        InstantiateSquares();
+        
+        FloodFill(targetIdx);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public bool IsIndexOpen(int idx)
+    {
+        return (_bb.getData() & (1UL << idx)) > 0;
+    }
+    
+    public int WorldToIndex(Vector2 worldPos)
+    {
+        // ideally, worldPos is exactly the same as a square pos, let's assume that first
+        // convert formula for position to translate back into index
+        
+        // save bounds for convenience
+        Vector2 bounds = prefab.GetComponent<SpriteRenderer>().bounds.size;
+        // who says you don't use algebra after high school?
+        int y = (int)((worldPos.y - origin.position.y - ((bounds.y) / 2)) / bounds.y),
+            x = (int)(((worldPos.x - origin.position.x - ((bounds.x) / 2)) / bounds.x) - 7)*-1;
+        
+        // formula for index used from before
+        return y * 8 + x;
+    }
+    private void InstantiateSquares()
+    {
+        for (int y = 0; y < 8; y++)
+        {
+            for (int x = 0; x < 8; x++)
+            {
+                int index = y * 8 + x;
+                
+                // if there is a 1 here, open
+                Vector2 pos = new Vector2(
+                    origin.position.x + prefab.GetComponent<SpriteRenderer>().bounds.size.x / 2 +
+                    prefab.GetComponent<SpriteRenderer>().bounds.size.x * (7 - x),
+                    origin.position.y + prefab.GetComponent<SpriteRenderer>().bounds.size.y / 2 +
+                    prefab.GetComponent<SpriteRenderer>().bounds.size.y * y);
+                
+                GameObject squarePrefab = Instantiate(prefab);
+                squarePrefab.transform.position = new Vector3(pos.x, pos.y);
+                
+                // keeping it with branching behavior because identifier is not concrete yet
+                if ((_bb.getData() & (1UL << index)) > 0)
+                {
+                    // squarePrefab.GetComponent<SpriteRenderer>().color = Color.green;
+                }
+                else // else, obstacle
+                {
+                    squarePrefab.GetComponent<SpriteRenderer>().color = Color.gray4;
+                }
+
+                squares[index] = squarePrefab;
+            }
+        }
+
+        initialized = true;
+    }
+
+    private void FloodFill(int srcIndex)
+    {
+        // if the square at this index is obstacle, return/fail
+        
+        // check in 4 directions, BFS, init distance, queue
+        // checking in 4 directions by index in a bitboard
+            // bitboard & (1UL << index)
+        // if square at each index is open, add into queue
+        // per loop in while, increase distance
+        
+        // how to check if square at index is obstacle, bitboard at index 0 or 1
+        if ((_bb.getData() & (1UL << srcIndex)) == 0) // if square at index is obstacle
+        {
+            Debug.Log("Tried to flood fill in a wall!");
+            return;
+        }
+
+        // how to check all 4 directions with bb?
+        // shifting, << 8 and 1, >> 8 and 1
+        
+        // with index = y*width + x, x = index%width and y = index/width
+
+        // Bitboard print = new Bitboard((_bb.getData() & ~eastMask));
+        // print.printBitboard();
+
+        int distance = 0;
+        Queue<int> q = new Queue<int>();
+        q.Enqueue(srcIndex);
+        int[] visited = new int[64];
+        const int defaultValue = -1;
+        Array.Fill(visited, defaultValue);
+        while (q.Count != 0)
+        {
+            distance++;
+            int size = q.Count;
+            for (int i = 0; i < size; ++i)
+            {
+                int currIndex = q.Dequeue();
+                visited[currIndex] = distance;
+                
+                // assign distance to square at current index
+                squares[currIndex].GetComponent<SpriteRenderer>().color = new Color(1-(0.08f*(distance-1)), 1-(0.08f*(distance-1)), 1f);
+                // now check 4 directions
+                
+                // check north
+                
+                // condition: if currIndex is on top row, don't check north
+                
+                if ((((_bb.getData() & northMask) & (1UL << (currIndex + 8))) != 0) &&
+                    ((visited[currIndex + 8] > distance) || (visited[currIndex + 8] == -1)))
+                {
+                    // north of current is open
+                    q.Enqueue(currIndex + 8);
+                }
+                // check south
+                if ((((_bb.getData() & southMask) & (1UL << (currIndex - 8))) != 0) &&
+                    ((visited[currIndex - 8] > distance) || (visited[currIndex - 8] == -1)))
+                {
+                    // south is open
+                    q.Enqueue(currIndex - 8);
+                }
+                // check west
+                if ((((_bb.getData() & westMask) & (1UL << (currIndex - 1))) != 0) &&
+                ((visited[currIndex - 1] > distance) || (visited[currIndex - 1] == -1)))
+                {
+                    // west is open
+                    q.Enqueue(currIndex - 1);
+                }
+                // check east
+                if ((((_bb.getData() & eastMask) & (1UL << (currIndex + 1))) != 0) &&
+                ((visited[currIndex + 1] > distance) || (visited[currIndex + 1] == -1)))
+                {
+                    // east is open
+                    q.Enqueue(currIndex + 1);
+                }
+            }
+        }
+
+        distances = visited;
+    }
+
+    public bool CreatePathToTarget(Queue<int> path, int srcIdx)
+    {
+        // if unreachable
+        if (distances[srcIdx] == -1)
+        {
+            Debug.Log("Cannot reach target from this index!");
+            return false;
+        }
+        path.Clear();
+        // check distances in 4 directions, can't use bit boards then
+        int[] dirs = { -1, 0, 1, 0, -1 };
+
+        int currIdx = srcIdx;
+        // can do this because flood fill already considers cells that where it is impossible to reach
+        while (currIdx != targetIdx)
+        {
+            // minimize space taken up by bestDistance
+            int bestDist = Int16.MaxValue, bestIdx = currIdx;
+            // check 4 dirs here with for loop, update 
+            for (int i = 0; i < 4; ++i)
+            {
+                int offset = dirs[i+1] * 8 + dirs[i];
+                // Debug.Log("Offset: " + offset);
+                // Debug.Log("Other Offset: " + otherOffset);
+                if (currIdx + offset > 63 || currIdx + offset < 0 || distances[currIdx + offset] == -1)
+                {
+                    continue;
+                }
+                // Debug.Log("===== NEXT  =====");
+                if (distances[currIdx + offset] < bestDist)
+                {
+                    bestDist = distances[currIdx + offset];
+                    bestIdx = currIdx + offset;
+                }
+
+                if (currIdx + offset == targetIdx)
+                {
+                    path.Enqueue(targetIdx);
+                    return true;
+                }
+            }
+            path.Enqueue(bestIdx);
+            currIdx = bestIdx;
+        }
+
+        return true;
+    }
+}

--- a/Assets/Scripts/Pathfinding_Scripts/BbGrid.cs.meta
+++ b/Assets/Scripts/Pathfinding_Scripts/BbGrid.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3515abf6f8e8a8f4598b3ebaeaf6a1a8

--- a/Assets/Scripts/Pathfinding_Scripts/Bitboards.cs
+++ b/Assets/Scripts/Pathfinding_Scripts/Bitboards.cs
@@ -1,0 +1,116 @@
+using System;
+using UnityEngine;
+using System.Numerics;
+public static class BitOps
+{
+    // de Bruijn trick
+    private static readonly int[] DeBruijnIdx64 = new int[64]
+    {
+        // all precomputed indices
+        0, 1, 56, 2, 57, 49, 28, 3, 
+        61, 58, 50, 42, 38, 29, 17, 4, 
+        62, 55, 48, 27, 60, 41, 37, 16, 
+        54, 47, 26, 40, 36, 15, 53, 25, 
+        59, 51, 43, 39, 18, 63, 52, 44, 
+        19, 45, 20, 46, 21, 22, 23, 24, 
+        5, 6, 7, 8, 9, 10, 11, 12, 
+        13, 14, 30, 31, 32, 33, 34, 35 
+    };
+
+    public static int TrailingZeroCount(ulong value) 
+    {
+        if (value == 0UL) 
+            return 64; // match common convention: CTZ(0) = bit width, in this case 64
+
+        // some voodoo magic
+        ulong isolated = value & (~value + 1UL); // isolate lowest set bit (one-hot mask?)
+        ulong magic = isolated * 0x03F79D71B4CB0A89UL; // Multiply by de Bruijn constant to encode index
+        int index = (int)(magic >> 58); // Use top 6 bits as table index (64 entries)
+        return DeBruijnIdx64[index]; // Return bit position of isolated lowest set bit
+    }
+}
+
+public static class BitIter // For each set bit function that is used with manually defined function
+{
+    public static void ForEachSetBit(ulong data, Action<int> func)
+    {
+        while (data != 0UL)
+        {
+            int index = BitOps.TrailingZeroCount(data);
+            func(index);
+            data &= data - 1UL;
+        }
+    }
+}
+
+public struct Bitboard
+{
+    private ulong _data;
+
+    public Bitboard(ulong data)
+    {
+        _data = data;
+    }
+
+    public void setData(ulong data)
+    {
+        _data = data;
+    }
+
+    public ulong getData()
+    {
+        return _data;
+    }
+        
+    
+    public void ForEachBit(Action<int> func)
+    {
+        BitIter.ForEachSetBit(_data, func);
+    }
+
+    private void printInt(int val)
+    {
+        Debug.Log(val);
+    }
+
+    public void printBitboard()
+    {
+        for (int x = 7; x >= 0; x--)
+        {
+            string s = "";
+            for (int y = 7; y >= 0; y--)
+            {
+                int cell = x * 8 + y;
+                if ((_data & (1UL << cell)) > 0)
+                {
+                    s += "X";
+                }
+                else
+                {
+                    s += ".";
+                }
+
+                s += " ";
+            }
+            Debug.Log(s);
+        }
+    }
+}
+
+public class Bitboards : MonoBehaviour
+{
+    private Bitboard bb;
+    
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        bb.setData(0b0101010100000000111111110101001011000110000011110011001111110000);
+        bb.printBitboard();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Pathfinding_Scripts/Bitboards.cs.meta
+++ b/Assets/Scripts/Pathfinding_Scripts/Bitboards.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b1ee6cf4964fed043a32ef5169532f9c

--- a/Assets/Scripts/Pathfinding_Scripts/NPC.cs
+++ b/Assets/Scripts/Pathfinding_Scripts/NPC.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+public class NPC : MonoBehaviour
+{
+    [SerializeField] private float moveSpeed = 1f;
+    [SerializeField] private float turnSpeed = 720f; // in degrees per second
+    [SerializeField] private float arrivedDistance = 0.02f; // how close do you need to be to count as "arrived"
+    public Vector2 debugMove = new Vector2(10f, 10f);
+
+    private Vector2 _targetPos;
+    private bool _hasTarget;
+
+    public event Action<NPC> Arrived; // event that passes the NPC that arrived
+    
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        _hasTarget = false;
+        if (debugMove != Vector2.zero)
+        {
+            SetMoveTarget(debugMove); 
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        UpdateMove();
+    }
+    private void UpdateMove()
+    {
+        if (!_hasTarget)
+        {
+            return;
+        }
+
+        float z = transform.position.z; // shouldn't ever change
+        Vector2 currentPos = transform.position;
+        // vector points from current position to target position
+        Vector2 posToTarget = _targetPos - currentPos; 
+
+        // direct distance to target
+        float dist = posToTarget.magnitude;
+
+        if (dist <= arrivedDistance) // if we're close enough to our target
+        {
+            transform.position = new Vector3(_targetPos.x, _targetPos.y, z); // snap to target (maybe not needed)
+            _hasTarget = false;
+            Arrived?.Invoke(this);
+            return;
+        }
+        
+        // posToTarget vector to get the direction
+        Vector2 dir = posToTarget / dist; 
+        
+        // Moving
+        float step = moveSpeed * Time.deltaTime;
+        // use built in function for moving
+        Vector2 nextPos = Vector2.MoveTowards(currentPos, _targetPos, step); 
+        transform.position = new Vector3(nextPos.x, nextPos.y, z);
+        
+        // Rotate to face dir
+        // convert direction vector to angle in degrees, -90 because default faces up
+        float destAngle = (Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg) - 90f; 
+
+        // get the current z rotation angle (apparently z for 2D)
+        float currentAngle = transform.eulerAngles.z;
+        // use built in function to turn smoothly
+        float newAngle = Mathf.MoveTowardsAngle(currentAngle, destAngle, turnSpeed * Time.deltaTime);
+        // Quaternion things, idk
+        transform.rotation = Quaternion.Euler(0f, 0f, newAngle);
+    }
+
+    
+    public void SetMoveTarget(Vector2 dest)
+    {
+        _targetPos = dest;
+        _hasTarget = true;
+    }
+
+    public void ClearTarget()
+    {
+        _hasTarget = false;
+    }
+
+    public bool HasTarget()
+    {
+        return _hasTarget;
+    }
+
+}

--- a/Assets/Scripts/Pathfinding_Scripts/NPC.cs.meta
+++ b/Assets/Scripts/Pathfinding_Scripts/NPC.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dce2799d57e8c944da061cd159cf2376

--- a/Assets/Scripts/Pathfinding_Scripts/NPCNetwork.cs
+++ b/Assets/Scripts/Pathfinding_Scripts/NPCNetwork.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class NPCNetwork : MonoBehaviour
+{
+    [SerializeField] private Dictionary<NPC, Queue<int>> _agentPaths = new Dictionary<NPC, Queue<int>>();
+    [SerializeField] private NPCSpawner spawner;
+    public GameObject square;
+    private bool done = false;
+
+    private BbGrid _grid;
+    // private Queue<int> _path = new Queue<int>();
+    
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        _grid = spawner.grid;
+        RegisterAgent(spawner.SpawnAgentOnIndex(54));
+        RegisterAgent(spawner.SpawnAgentOnIndex(30));
+        // spawner.SpawnAgentOnIndex(54);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        // should only ever be run once, ignore warnings of expensive calls
+        if (_grid.initialized && !done && spawner.spawned && _agentPaths.Count > 0)
+        {
+            // agents[0].SetMoveTarget(grid.squares[9].transform.position);
+            // RegisterAgent(agents[0]);
+            foreach (KeyValuePair<NPC, Queue<int>> agent in _agentPaths)
+            {
+                MoveAgentToTarget(agent.Key);
+            }
+            done = true;
+        }
+    }
+
+    public void RegisterAgent(NPC agent)
+    {
+        if (!agent) return;
+        _agentPaths.Add(agent, new Queue<int>());
+        agent.Arrived += OnAgentArrived;
+    }
+
+    public void UnregisterAgent(NPC agent)
+    {
+        agent.Arrived -= OnAgentArrived;
+        _agentPaths.Remove(agent);
+    }
+
+    private void OnAgentArrived(NPC agent)
+    {
+        // temp code
+        // if (agent != agents[0])
+        // {
+        //     return;
+        // }
+        // has been moving already
+        // not a deeper clone, so should be a reference
+        Queue<int> path = _agentPaths[agent];
+        if (path.Count != 0)
+        {
+            agent.SetMoveTarget(_grid.squares[path.Dequeue()].transform.position);
+        }
+        
+    }
+    
+    private void MoveAgentToTarget(NPC agent)
+    {
+        // not a deeper clone, so should be a reference
+        Queue<int> path = _agentPaths[agent];
+        // get index that agent is at
+        int agentToGridIndex = _grid.WorldToIndex(agent.transform.position);
+        if (!_grid.CreatePathToTarget(path, agentToGridIndex))
+        {
+            // PrintPath(path);
+            return;
+        }
+        // PrintPath(path);
+        // start moving the agent
+        agent.SetMoveTarget(_grid.squares[path.Dequeue()].transform.position);
+    }
+
+    private void PrintPath(Queue<int> path)
+    {
+        Queue<int> copy = new Queue<int>(path);
+        string s = "";
+        for (int i = 0; i < path.Count-1; ++i)
+        {
+            s += copy.Dequeue() + ", ";
+        }
+
+        s += copy.Dequeue();
+        
+        Debug.Log(s);
+    }
+    
+}

--- a/Assets/Scripts/Pathfinding_Scripts/NPCNetwork.cs.meta
+++ b/Assets/Scripts/Pathfinding_Scripts/NPCNetwork.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 862595f16f44d8244acec5349546fed1

--- a/Assets/Scripts/Pathfinding_Scripts/NPCSpawner.cs
+++ b/Assets/Scripts/Pathfinding_Scripts/NPCSpawner.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+public class NPCSpawner : MonoBehaviour
+{
+    [SerializeField] private GameObject agent;
+    [SerializeField] private int nToSpawn;
+    public BbGrid grid;
+
+    public bool spawned;
+    
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        // init vals
+        spawned = false;
+        // spawn npcs
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public void SpawnAgents(int numToSpawn)
+    {
+        // for loop from 0 to numToSpawn
+            // get random number between 0-64
+            // if valid spot, spawn an agent at position of square at index
+            // send agent into network
+                // we can do this with signals
+    }
+
+    public NPC SpawnAgentOnIndex(int idx)
+    {
+        if (!grid.IsIndexOpen(idx))
+        {
+            Debug.Log("tried to spawn in an invalid cell!");
+            return null;
+        }
+        GameObject npc = Instantiate(agent);
+        npc.transform.position = grid.squares[idx].transform.position;
+        spawned = true;
+        return npc.GetComponent<NPC>();
+    }
+    
+}

--- a/Assets/Scripts/Pathfinding_Scripts/NPCSpawner.cs.meta
+++ b/Assets/Scripts/Pathfinding_Scripts/NPCSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6002d79961bf0649a1df7133628caa3

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   m_SeeAllPackageVersions: 0
   m_DismissPreviewPackagesInUse: 0
   oneTimeWarningShown: 0
-  oneTimeDeprecatedPopUpShown: 0
+  oneTimePackageErrorsPopUpShown: 1
   m_Registries:
   - m_Id: main
     m_Name: 
@@ -27,11 +27,14 @@ MonoBehaviour:
     m_IsDefault: 1
     m_Capabilities: 7
     m_ConfigSource: 0
+    m_Compliance:
+      m_Status: 0
+      m_Violations: []
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -898
-    m_OriginalInstanceId: -900
+    m_UserModificationsInstanceId: -894
+    m_OriginalInstanceId: -896
   m_LoadAssets: 0


### PR DESCRIPTION
## Summary
- **What does this PR change?**
  - Adds a bitboard-represented 8×8 grid (`BbGrid.cs`) with BFS wavefront flood-fill for distance precomputation
  - Adds a greedy path-following system (`CreatePathToTarget`) that walks the precomputed distance gradient toward a target index
  - Adds an NPC movement component (`NPC.cs`) with smooth translation and rotation toward waypoints, plus an `Arrived` event
  - Adds an `NPCSpawner` for placing agents on valid grid cells by index
  - Adds an `NPCNetwork` that registers agents, builds their paths, and chains movement through waypoints on arrival
  - Adds supporting bitboard utilities (`Bitboards.cs`) including a de Bruijn trailing-zero-count trick and a `ForEachSetBit` iterator
  - Adds Unity prefabs and scene (`Pathfinding.unity`) wiring everything together

- **Why are these changes needed now?**
  - Establishes the foundational grid representation and NPC pathfinding layer. The bitboard approach keeps the grid data compact and makes directional masking operations cheap, which is a good fit for a system that may later scale to larger maps or more agents.

---

## Technical details
- **RoomTree / WFC changes (if any)**
  - None — grid layout is currently hardcoded as a single `ulong` bitmask in `BbGrid.Start()`.

- **DualGrid / canonical tiles changes (if any)**
  - None directly, but `BbGrid` instantiates `Square` prefabs positionally using the `SpriteRenderer` bounds as a consistent tile size unit, so the visual grid is tile-sized and spatially consistent.

- **Other systems touched**
  - **Grid / Bitboard layer (`BbGrid.cs`, `Bitboards.cs`):** The board is a single `ulong` where each bit represents an open (1) or obstacle (0) cell. Cardinal-direction movement is guarded by four precomputed edge masks (`northMask`, `southMask`, `westMask`, `eastMask`) to prevent index wraparound across grid boundaries. On `Start`, a BFS flood-fill runs from `targetIdx` and writes per-cell distances into `distances[64]`. Squares are tinted blue-to-white based on their distance for visual debugging.
  - **Pathfinding (`BbGrid.CreatePathToTarget`):** At query time, an agent's world position is converted to a grid index via `WorldToIndex`, then `CreatePathToTarget` greedily descends the precomputed distance field, appending indices to a `Queue<int>` until `targetIdx` is reached.
  - **NPC movement (`NPC.cs`):** Each frame, `UpdateMove` translates the NPC toward `_targetPos` using `Vector2.MoveTowards` and rotates it to face its direction of travel using `Mathf.MoveTowardsAngle`. When within `arrivedDistance`, it fires the `Arrived` event and clears its target.
  - **Agent coordination (`NPCNetwork.cs`, `NPCSpawner.cs`):** `NPCNetwork` holds a `Dictionary<NPC, Queue<int>>` of per-agent path queues. When an agent fires `Arrived`, `OnAgentArrived` dequeues the next index and issues a new `SetMoveTarget`. `NPCSpawner.SpawnAgentOnIndex` validates the cell is open before instantiating and returns the `NPC` component for immediate registration.

---

## Testing
- **Manual testing**
  - [ ] RoomTree demo scene runs without errors
  - [ ] Regular WFC demo scene runs without errors
  - [ ] DualGrid renders correctly (no obvious gaps or misaligned walls)
  - [x] No regressions in core gameplay scenes

- **Automated tests**
  - [ ] All existing tests pass
  - [ ] New tests added for this change (if applicable)

Describe any specific test steps:
1. **Scene(s) opened:** `Pathfinding.unity`
2. **Buttons / menu items used:** Enter Play Mode. No additional input needed — agents spawn and begin pathing automatically on `Start`.
3. **Expected vs actual:**
   - Grid renders with gray obstacle cells and blue-gradient open cells (lighter = closer to target)
   - Two NPCs spawn at indices 54 and 30, each independently trace the distance gradient to `targetIdx`, and chain through their queued waypoints after each arrival event fires
   - Console should show no errors; wall-spawn or unreachable-target edge cases log descriptive messages via `Debug.Log`

---

## Risks & roll-back plan
- **Potential side effects**
  - `FloodFill` and `InstantiateSquares` are both called in `Start` and call `GetComponent<SpriteRenderer>()` per square per frame of setup — fine at 64 cells but would need caching if the grid size ever grows significantly
  - `WorldToIndex` assumes NPCs are snapped exactly to square centers; fractional positions between tiles could return a wrong or out-of-bounds index
  - `NPCNetwork.Update` polls `_grid.initialized` and a `done` flag every frame until first run — low cost but worth replacing with an event or coroutine if the pattern spreads
  - The distance field is static: it's computed once at `Start` for a fixed `targetIdx`. Any runtime obstacle changes or target updates would require re-running `FloodFill`

- **How to roll back**
  - Revert this PR in full. No existing systems depend on these files yet, so removal is clean with no downstream breakage.

---

## Checklist
- [x] Code builds and runs locally
- [x] New/changed behavior is documented (markdown docs or comments where appropriate)
- [x] Any new public APIs / assets are named consistently with the project style
- [ ] I've checked for leftover debug logs / temporary code
  - Several `Debug.Log` calls and commented-out blocks remain in `BbGrid.cs` and `NPCNetwork.cs` from active development — should be cleaned up before merging to main